### PR TITLE
Update stubs-manager.js

### DIFF
--- a/src/stubs/stubs-manager.js
+++ b/src/stubs/stubs-manager.js
@@ -108,9 +108,6 @@ export default class StubsManager {
 
         if (!_.includes(settings['python.analysis.typeshedPaths'], path.join('.vscode', 'Pico-Stub')))
             settings['python.analysis.typeshedPaths'].push(path.join('.vscode', 'Pico-Stub'));
-        
-        if (!_.includes(settings['python.analysis.typeshedPaths'], path.join('lib')))
-            settings['python.analysis.typeshedPaths'].push(path.join('lib'));
 
         settings['python.languageServer'] = 'Pylance';
         settings['python.analysis.typeCheckingMode'] = 'basic';
@@ -121,6 +118,9 @@ export default class StubsManager {
 
         if (!_.includes(settings['python.analysis.extraPaths'], path.join('.vscode', 'Pico-Stub', 'stubs')))
             settings['python.analysis.extraPaths'].push(path.join('.vscode', 'Pico-Stub', 'stubs'));
+        
+        if (!_.includes(settings['python.analysis.extraPaths'], path.join('lib')))
+            settings['python.analysis.extraPaths'].push(path.join('lib'));
 
         await fsp.writeFile(path.join(vsc, 'settings.json'), JSON.stringify(settings, null, 4));
     }

--- a/src/stubs/stubs-manager.js
+++ b/src/stubs/stubs-manager.js
@@ -108,6 +108,9 @@ export default class StubsManager {
 
         if (!_.includes(settings['python.analysis.typeshedPaths'], path.join('.vscode', 'Pico-Stub')))
             settings['python.analysis.typeshedPaths'].push(path.join('.vscode', 'Pico-Stub'));
+        
+        if (!_.includes(settings['python.analysis.typeshedPaths'], path.join('lib')))
+            settings['python.analysis.typeshedPaths'].push(path.join('lib'));
 
         settings['python.languageServer'] = 'Pylance';
         settings['python.analysis.typeCheckingMode'] = 'basic';


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Add MicroPython lib folder.

This folder is used to store libraries that micropython can import

You can verify this with a fresh install of micropython on the pico w, run the following

```
import upip
upip.get_install_path()
```

## Does this close any currently open issues?

Nope

## Any relevant logs, error output, etc?
*(If it’s long, please paste to https://gist.github.com and insert the link here)*


## Any other comments?
